### PR TITLE
First pass at more restricted read-only permissions for AWSIAMAllUsersGroup

### DIFF
--- a/templates/accounts.yaml
+++ b/templates/accounts.yaml
@@ -111,7 +111,6 @@ Resources:
     Type: 'AWS::IAM::Group'
     Properties:
       ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/ReadOnlyAccess
         - !Ref AWSIAMEnforceMfaPolicy
   AWSIAMBillingManagersGroup:
     Type: 'AWS::IAM::Group'


### PR DESCRIPTION
This is an attempt to narrow the read-only permissions. Currently any account that is part of AWSIAMAllUsersGroup has the global read-only policy. In order to make a more streamlined Service Catalog experience, it requires that the permissions for the group be pared back. I did this in AWSIAMAllUsersGroup and I believe removing `arn:aws:iam::aws:policy/ReadOnlyAccess` there is the right thing to do. However, perhaps the additional policies should be added to '${AWS::Region}-sc-enduser-iam-EndUserGroupName' rather than AWSIAMAllUsersGroup.

The end result is that we still have four user tiers:
1. SC users, most restricted
2. Developer Users, who have Power User 
3. Admin
4. Billing
