### PR TITLE
Replace references to template lib 

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The purpose of this project is to build a self service provisioning
 system using the
 [AWS service catalog](https://docs.aws.amazon.com/servicecatalog/latest/adminguide/introduction.html).
 
-We are leveraging the [AWS service catalog reference architecure](https://github.com/Sage-Bionetworks/aws-service-catalog-reference-architectures)
+We are leveraging the [AWS service catalog reference architecure](https://github.com/Sage-Bionetworks/scipoolprod-sc-lib-infra)
 to build out the service catalog.
 
 ## Instructions to create or update CF stacks

--- a/config/prod/sc-ec2vpc-launchrole.yaml
+++ b/config/prod/sc-ec2vpc-launchrole.yaml
@@ -4,6 +4,6 @@ dependencies:
   - "prod/essentials.yaml"
 hooks:
   before_create:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-service-catalog-reference-architectures/master/iam/sc-ec2vpc-launchrole.yaml --create-dirs -o templates/remote/sc-ec2vpc-launchrole.yaml"
+    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/scipoolprod-sc-lib-infra/master/iam/sc-ec2vpc-launchrole.yaml --create-dirs -o templates/remote/sc-ec2vpc-launchrole.yaml"
   before_update:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-service-catalog-reference-architectures/master/iam/sc-ec2vpc-launchrole.yaml --create-dirs -o templates/remote/sc-ec2vpc-launchrole.yaml"
+    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/scipoolprod-sc-lib-infra/master/iam/sc-ec2vpc-launchrole.yaml --create-dirs -o templates/remote/sc-ec2vpc-launchrole.yaml"

--- a/config/prod/sc-ecs-launchrole.yaml
+++ b/config/prod/sc-ecs-launchrole.yaml
@@ -4,6 +4,6 @@ dependencies:
   - "prod/essentials.yaml"
 hooks:
   before_create:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-service-catalog-reference-architectures/master/iam/sc-ecs-launchrole.yaml --create-dirs -o templates/remote/sc-ecs-launchrole.yaml"
+    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/scipoolprod-sc-lib-infra/master/iam/sc-ecs-launchrole.yaml --create-dirs -o templates/remote/sc-ecs-launchrole.yaml"
   before_update:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-service-catalog-reference-architectures/master/iam/sc-ecs-launchrole.yaml --create-dirs -o templates/remote/sc-ecs-launchrole.yaml"
+    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/scipoolprod-sc-lib-infra/master/iam/sc-ecs-launchrole.yaml --create-dirs -o templates/remote/sc-ecs-launchrole.yaml"

--- a/config/prod/sc-emr-launchrole.yaml
+++ b/config/prod/sc-emr-launchrole.yaml
@@ -4,6 +4,6 @@ dependencies:
   - "prod/essentials.yaml"
 hooks:
   before_create:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-service-catalog-reference-architectures/master/iam/sc-emr-launchrole.yaml --create-dirs -o templates/remote/sc-emr-launchrole.yaml"
+    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/scipoolprod-sc-lib-infra/master/iam/sc-emr-launchrole.yaml --create-dirs -o templates/remote/sc-emr-launchrole.yaml"
   before_update:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-service-catalog-reference-architectures/master/iam/sc-emr-launchrole.yaml --create-dirs -o templates/remote/sc-emr-launchrole.yaml"
+    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/scipoolprod-sc-lib-infra/master/iam/sc-emr-launchrole.yaml --create-dirs -o templates/remote/sc-emr-launchrole.yaml"

--- a/config/prod/sc-enduser-iam.yaml
+++ b/config/prod/sc-enduser-iam.yaml
@@ -4,6 +4,6 @@ dependencies:
   - "prod/essentials.yaml"
 hooks:
   before_create:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-service-catalog-reference-architectures/master/iam/sc-enduser-iam.yaml --create-dirs -o templates/remote/sc-enduser-iam.yaml"
+    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/scipoolprod-sc-lib-infra/master/iam/sc-enduser-iam.yaml --create-dirs -o templates/remote/sc-enduser-iam.yaml"
   before_update:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-service-catalog-reference-architectures/master/iam/sc-enduser-iam.yaml --create-dirs -o templates/remote/sc-enduser-iam.yaml"
+    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/scipoolprod-sc-lib-infra/master/iam/sc-enduser-iam.yaml --create-dirs -o templates/remote/sc-enduser-iam.yaml"

--- a/config/prod/sc-glue-launchrole.yaml
+++ b/config/prod/sc-glue-launchrole.yaml
@@ -4,6 +4,6 @@ dependencies:
   - "prod/essentials.yaml"
 hooks:
   before_create:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-service-catalog-reference-architectures/master/iam/sc-glue-launchrole.yaml --create-dirs -o templates/remote/sc-glue-launchrole.yaml"
+    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/scipoolprod-sc-lib-infra/master/iam/sc-glue-launchrole.yaml --create-dirs -o templates/remote/sc-glue-launchrole.yaml"
   before_update:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-service-catalog-reference-architectures/master/iam/sc-glue-launchrole.yaml --create-dirs -o templates/remote/sc-glue-launchrole.yaml"
+    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/scipoolprod-sc-lib-infra/master/iam/sc-glue-launchrole.yaml --create-dirs -o templates/remote/sc-glue-launchrole.yaml"

--- a/config/prod/sc-portfolio-ec2.yaml
+++ b/config/prod/sc-portfolio-ec2.yaml
@@ -8,9 +8,9 @@ parameters:
   CreateEndUsers: "No"
   LinkedRole1: ""
   LinkedRole2: ""
-  RepoRootURL: "https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-service-catalog-reference-architectures/master/"
+  RepoRootURL: "https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/scipoolprod-sc-lib-infra/master/"
 hooks:
   before_create:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-service-catalog-reference-architectures/master/ec2/sc-portfolio-ec2.yaml --create-dirs -o templates/remote/sc-portfolio-ec2.yaml"
+    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/scipoolprod-sc-lib-infra/master/ec2/sc-portfolio-ec2.yaml --create-dirs -o templates/remote/sc-portfolio-ec2.yaml"
   before_update:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-service-catalog-reference-architectures/master/ec2/sc-portfolio-ec2.yaml --create-dirs -o templates/remote/sc-portfolio-ec2.yaml"
+    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/scipoolprod-sc-lib-infra/master/ec2/sc-portfolio-ec2.yaml --create-dirs -o templates/remote/sc-portfolio-ec2.yaml"

--- a/config/prod/sc-portfolio-s3.yaml
+++ b/config/prod/sc-portfolio-s3.yaml
@@ -8,9 +8,9 @@ parameters:
   CreateEndUsers: "No"
   LinkedRole1: ""
   LinkedRole2: ""
-  RepoRootURL: "https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-service-catalog-reference-architectures/master/"
+  RepoRootURL: "https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/scipoolprod-sc-lib-infra/master/"
 hooks:
   before_create:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-service-catalog-reference-architectures/master/s3/sc-portfolio-s3.yaml --create-dirs -o templates/remote/sc-portfolio-s3.yaml"
+    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/scipoolprod-sc-lib-infra/master/s3/sc-portfolio-s3.yaml --create-dirs -o templates/remote/sc-portfolio-s3.yaml"
   before_update:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-service-catalog-reference-architectures/master/s3/sc-portfolio-s3.yaml --create-dirs -o templates/remote/sc-portfolio-s3.yaml"
+    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/scipoolprod-sc-lib-infra/master/s3/sc-portfolio-s3.yaml --create-dirs -o templates/remote/sc-portfolio-s3.yaml"

--- a/config/prod/sc-portfolio-vpc.yaml
+++ b/config/prod/sc-portfolio-vpc.yaml
@@ -8,9 +8,9 @@ parameters:
   CreateEndUsers: "No"
   LinkedRole1: ""
   LinkedRole2: ""
-  RepoRootURL: "https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-service-catalog-reference-architectures/master/"
+  RepoRootURL: "https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/scipoolprod-sc-lib-infra/master/"
 hooks:
   before_create:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-service-catalog-reference-architectures/master/vpc/sc-portfolio-vpc.yaml --create-dirs -o templates/remote/sc-portfolio-vpc.yaml"
+    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/scipoolprod-sc-lib-infra/master/vpc/sc-portfolio-vpc.yaml --create-dirs -o templates/remote/sc-portfolio-vpc.yaml"
   before_update:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-service-catalog-reference-architectures/master/vpc/sc-portfolio-vpc.yaml --create-dirs -o templates/remote/sc-portfolio-vpc.yaml"
+    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/scipoolprod-sc-lib-infra/master/vpc/sc-portfolio-vpc.yaml --create-dirs -o templates/remote/sc-portfolio-vpc.yaml"

--- a/config/prod/sc-rds-launchrole.yaml
+++ b/config/prod/sc-rds-launchrole.yaml
@@ -4,6 +4,6 @@ dependencies:
   - "prod/essentials.yaml"
 hooks:
   before_create:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-service-catalog-reference-architectures/master/iam/sc-rds-launchrole.yaml --create-dirs -o templates/remote/sc-rds-launchrole.yaml"
+    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/scipoolprod-sc-lib-infra/master/iam/sc-rds-launchrole.yaml --create-dirs -o templates/remote/sc-rds-launchrole.yaml"
   before_update:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-service-catalog-reference-architectures/master/iam/sc-rds-launchrole.yaml --create-dirs -o templates/remote/sc-rds-launchrole.yaml"
+    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/scipoolprod-sc-lib-infra/master/iam/sc-rds-launchrole.yaml --create-dirs -o templates/remote/sc-rds-launchrole.yaml"

--- a/config/prod/sc-s3-launchrole.yaml
+++ b/config/prod/sc-s3-launchrole.yaml
@@ -4,6 +4,6 @@ dependencies:
   - "prod/essentials.yaml"
 hooks:
   before_create:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-service-catalog-reference-architectures/master/iam/sc-s3-launchrole.yaml --create-dirs -o templates/remote/sc-s3-launchrole.yaml"
+    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/scipoolprod-sc-lib-infra/master/iam/sc-s3-launchrole.yaml --create-dirs -o templates/remote/sc-s3-launchrole.yaml"
   before_update:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-service-catalog-reference-architectures/master/iam/sc-s3-launchrole.yaml --create-dirs -o templates/remote/sc-s3-launchrole.yaml"
+    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/scipoolprod-sc-lib-infra/master/iam/sc-s3-launchrole.yaml --create-dirs -o templates/remote/sc-s3-launchrole.yaml"

--- a/config/prod/sc-serverless-launchrole.yaml
+++ b/config/prod/sc-serverless-launchrole.yaml
@@ -4,6 +4,6 @@ dependencies:
   - "prod/essentials.yaml"
 hooks:
   before_create:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-service-catalog-reference-architectures/master/iam/sc-serverless-launchrole.yaml --create-dirs -o templates/remote/sc-serverless-launchrole.yaml"
+    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/scipoolprod-sc-lib-infra/master/iam/sc-serverless-launchrole.yaml --create-dirs -o templates/remote/sc-serverless-launchrole.yaml"
   before_update:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-service-catalog-reference-architectures/master/iam/sc-serverless-launchrole.yaml --create-dirs -o templates/remote/sc-serverless-launchrole.yaml"
+    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/scipoolprod-sc-lib-infra/master/iam/sc-serverless-launchrole.yaml --create-dirs -o templates/remote/sc-serverless-launchrole.yaml"


### PR DESCRIPTION
swap aws-service-catalog-reference-architectures for scipoolprod-sc-lib-infra after creating the latter as a new template library repo

