### PR TITLE
Correct launch role in S3 portfolios

### DIFF
--- a/config/prod/sc-portfolio-s3-basic.yaml
+++ b/config/prod/sc-portfolio-s3-basic.yaml
@@ -5,7 +5,7 @@ dependencies:
   - "prod/sc-enduser-iam.yaml"
 parameters:
   ProductVersionName: "v1.0"
-  LaunchRoleName: "SCEC2LaunchRole"
+  LaunchRoleName: "SCS3LaunchRole"
   CreateEndUsers: "No"
   LinkedRole1: ""
   LinkedRole2: ""

--- a/config/prod/sc-portfolio-s3.yaml
+++ b/config/prod/sc-portfolio-s3.yaml
@@ -5,7 +5,7 @@ dependencies:
   - "prod/sc-enduser-iam.yaml"
 parameters:
   ProductVersionName: "v1.0"
-  LaunchRoleName: "SCEC2LaunchRole"
+  LaunchRoleName: "SCS3LaunchRole"
   CreateEndUsers: "No"
   LinkedRole1: ""
   LinkedRole2: ""


### PR DESCRIPTION
The S3 portfolios were using the EC2 launch role. Update to use SCS3LaunchRole.