### PR TITLE
SCEC2LaunchRole invoke permission for SsmParam

### DIFF
--- a/config/prod/cfn-ssm-param-permission.yaml
+++ b/config/prod/cfn-ssm-param-permission.yaml
@@ -1,0 +1,4 @@
+template_path: "cfn-ssm-param-permission.yaml"
+stack_name: "cfn-ssm-param-permission"
+dependencies:
+  - "prod/cfn-ssm-param-macro.yaml"

--- a/templates/cfn-ssm-param-permission.yaml
+++ b/templates/cfn-ssm-param-permission.yaml
@@ -1,0 +1,13 @@
+Description: Invoke permission for SsmParam Lambda Function
+AWSTemplateFormatVersion: 2010-09-09
+
+Resources:
+  InvokePermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !ImportValue
+        'Fn::Sub': '${AWS::Region}-cfn-ssm-param-macro-SsmParamFunctionArn'
+      Action: lambda:InvokeFunction
+      Principal: !Ref 'AWS::AccountId'
+      SourceArn: !ImportValue
+        'Fn::Sub': '${AWS::Region}-sc-ec2vpc-launchrole-LaunchRoleArn'


### PR DESCRIPTION
This grants lambda invoke permission for the SsmParam function to SCEC2LaunchRole. I placed this in scipoolprod-infra as I can't put this permission with the lambda template in aws-infra since it depends on a template in scipoolprod-sc-lib-infra and the lambda function is finally instantiated in scipoolprod-infra. Also, we may want to use SsmParam down the road outside of Service Catalog.