### PR TITLE
Add configs for development EC2 and S3 portfolios

### DIFF
--- a/config/prod/sc-portfolio-ec2-development.yaml
+++ b/config/prod/sc-portfolio-ec2-development.yaml
@@ -1,0 +1,16 @@
+template_path: "remote/sc-portfolio-ec2-development.yaml"
+stack_name: "sc-portfolio-ec2-development"
+dependencies:
+  - "prod/sc-ec2vpc-launchrole.yaml"
+  - "prod/sc-enduser-development-iam.yaml"
+parameters:
+  ProductVersionName: "v1.0"
+  LaunchRoleName: "SCEC2LaunchRole"
+  RepoRootURL: "https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/scipoolprod-sc-lib-infra/master/"
+  PrincipalRoleName1: "ServiceCatalogDevelopmentEndusers"
+  PrincipalGroupName1: "ServiceCatalogDevelopmentEndusers"
+hooks:
+  before_create:
+    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/scipoolprod-sc-lib-infra/master/ec2/sc-portfolio-ec2-development.yaml --create-dirs -o templates/remote/sc-portfolio-ec2-development.yaml"
+  before_update:
+    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/scipoolprod-sc-lib-infra/master/ec2/sc-portfolio-ec2-development.yaml --create-dirs -o templates/remote/sc-portfolio-ec2-development.yaml"

--- a/config/prod/sc-portfolio-ec2.yaml
+++ b/config/prod/sc-portfolio-ec2.yaml
@@ -4,11 +4,10 @@ dependencies:
   - "prod/sc-ec2vpc-launchrole.yaml"
   - "prod/sc-enduser-iam.yaml"
 parameters:
-  ProductVersionName: "v1.4"
+  ProductVersionName: "v1.5"
   LaunchRoleName: "SCEC2LaunchRole"
-  CreateEndUsers: "No"
-  LinkedRole1: ""
-  LinkedRole2: ""
+  PrincipalRoleName1: "ServiceCatalogEndusers"
+  PrincipalGroupName1: "ServiceCatalogEndusers"
   RepoRootURL: "https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/scipoolprod-sc-lib-infra/master/"
 hooks:
   before_create:

--- a/config/prod/sc-portfolio-s3-basic-development.yaml
+++ b/config/prod/sc-portfolio-s3-basic-development.yaml
@@ -1,0 +1,16 @@
+template_path: "remote/sc-portfolio-s3-basic-development.yaml"
+stack_name: "sc-portfolio-s3-basic-development"
+dependencies:
+  - "prod/sc-s3-launchrole.yaml"
+  - "prod/sc-enduser-development-iam.yaml"
+parameters:
+  ProductVersionName: "v1.2.0"
+  LaunchRoleName: "SCS3LaunchRole"
+  PrincipalRoleName1: "ServiceCatalogDevelopmentEndusers"
+  PrincipalGroupName1: "ServiceCatalogDevelopmentEndusers"
+  RepoRootURL: "https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/scipoolprod-sc-lib-infra/master/"
+hooks:
+  before_create:
+    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/scipoolprod-sc-lib-infra/master/s3/sc-portfolio-s3-basic-development.yaml --create-dirs -o templates/remote/sc-portfolio-s3-basic-development.yaml"
+  before_update:
+    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/scipoolprod-sc-lib-infra/master/s3/sc-portfolio-s3-basic-development.yaml --create-dirs -o templates/remote/sc-portfolio-s3-basic-development.yaml"

--- a/config/prod/sc-portfolio-s3-basic.yaml
+++ b/config/prod/sc-portfolio-s3-basic.yaml
@@ -4,11 +4,10 @@ dependencies:
   - "prod/sc-s3-launchrole.yaml"
   - "prod/sc-enduser-iam.yaml"
 parameters:
-  ProductVersionName: "v1.1.1"
+  ProductVersionName: "v1.2.0"
   LaunchRoleName: "SCS3LaunchRole"
-  CreateEndUsers: "No"
-  LinkedRole1: ""
-  LinkedRole2: ""
+  PrincipalRoleName1: "ServiceCatalogEndusers"
+  PrincipalGroupName1: "ServiceCatalogEndusers"
   RepoRootURL: "https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/scipoolprod-sc-lib-infra/master/"
 hooks:
   before_create:


### PR DESCRIPTION
- config to instantiate development portfolio for EC2
- config to instantiate development portfolio for S3
- update existing EC2 and S3 portfolios to use new treatment of principals
- This PR depends on https://github.com/Sage-Bionetworks/scipoolprod-sc-lib-infra/pull/53
- This PR also depends on https://github.com/Sage-Bionetworks/scipoolprod-sc-lib-infra/pull/54
