### PR TITLE
Add policy that allows searching provisioned products

### DIFF
--- a/config/prod/cfn-tag-instance-policy.yaml
+++ b/config/prod/cfn-tag-instance-policy.yaml
@@ -1,0 +1,2 @@
+template_path: "cfn-tag-instance-policy.yaml"
+stack_name: "cfn-tag-instance-policy"

--- a/templates/cfn-tag-instance-policy.yaml
+++ b/templates/cfn-tag-instance-policy.yaml
@@ -1,0 +1,21 @@
+Description: Policy with extra actions for tagging instances in Service Catalog
+AWSTemplateFormatVersion: 2010-09-09
+
+Resources:
+  TagInstancePolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Sid: SearchProvisionedProducts
+            Effect: 'Allow'
+            Action: 'servicecatalog:SearchProvisionedProducts'
+            Resource: '*'
+
+Outputs:
+  TagInstancePolicy:
+    Description: Policy with extra actions for tagging instances in Service Catalog
+    Value: !Ref TagInstancePolicy
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-TagInstancePolicy'


### PR DESCRIPTION
This policy gives permission to search provisioned products. It will be applied to the `InstanceRole` in service catalog library EC2 products. This permission is necessary to look up provisioned products, filtering on stack id, to retrieve the name a user assigned to a provisioned product when using the Service Catalog. That name will then be used to tag their instance. This is the first of two PRs for SC-29.