### PR TITLE
Fix for continued tag options difficulty -- just split templates

### DIFF
--- a/config/dev/sc-tag-options-dev.yaml
+++ b/config/dev/sc-tag-options-dev.yaml
@@ -1,4 +1,4 @@
-template_path: "sc-tag-options.j2"
+template_path: "sc-tag-options-dev.j2"
 stack_name: "sc-tag-options-dev"
 dependencies:
   - "dev/sc-portfolio-ec2-development.yaml"

--- a/templates/sc-tag-options-dev.j2
+++ b/templates/sc-tag-options-dev.j2
@@ -17,14 +17,16 @@ Resources:
       Key: "Project"
       Value: {{ project }}
 {% endfor %}
-{% for email in sceptre_user_data.OwnerEmails %}
-  {{ email.split('@')[0].replace('.','').replace('-','').replace('_','') }}OwnerEmailTag:
-    Type: AWS::ServiceCatalog::TagOption
-    Properties:
-      Active: true
-      Key: "OwnerEmail"
-      Value: {{ email }}
-{% endfor %}
+{% if 'OwnerEmails' in sceptre_user_data %}
+  {% for email in sceptre_user_data.OwnerEmails %}
+    {{ email.split('@')[0].replace('.','').replace('-','').replace('_','') }}OwnerEmailTag:
+      Type: AWS::ServiceCatalog::TagOption
+      Properties:
+        Active: true
+        Key: "OwnerEmail"
+        Value: {{ email }}
+  {% endfor %}
+{% endif %}
 
 {% for id in sceptre_user_data.ProductIDs %}
   {% for department in sceptre_user_data.Departments %}
@@ -41,13 +43,15 @@ Resources:
       ResourceId: "{{ id }}"
       TagOptionId: !Ref "{{ project.replace('.','').replace('-','').replace('_','').replace('/','') }}ProjectTag"
   {% endfor %}
-  {% for email in sceptre_user_data.OwnerEmails %}
-  {{ email.split('@')[0].replace('.','').replace('-','').replace('_','') }}TagAssociationProd{{ id.split('-')[1] }}:
-    Type: AWS::ServiceCatalog::TagOptionAssociation
-    Properties:
-      ResourceId: "{{ id }}"
-      TagOptionId: !Ref "{{ email.split('@')[0].replace('.','').replace('-','').replace('_','') }}OwnerEmailTag"
-  {% endfor %}
+  {% if 'OwnerEmails' in sceptre_user_data %}
+    {% for email in sceptre_user_data.OwnerEmails %}
+    {{ email.split('@')[0].replace('.','').replace('-','').replace('_','') }}TagAssociationProd{{ id.split('-')[1] }}:
+      Type: AWS::ServiceCatalog::TagOptionAssociation
+      Properties:
+        ResourceId: "{{ id }}"
+        TagOptionId: !Ref "{{ email.split('@')[0].replace('.','').replace('-','').replace('_','') }}OwnerEmailTag"
+    {% endfor %}
+  {% endif %}
 {% endfor %}
 
 Outputs:
@@ -63,9 +67,11 @@ Outputs:
     Export:
       Name: !Sub "${AWS::Region}-${AWS::StackName}-{{ project.replace('.','').replace('-','').replace('_','').replace('/','') }}ProjectTag"
 {% endfor %}
-{% for email in sceptre_user_data.OwnerEmails %}
-  {{ email.split('@')[0].replace('.','').replace('-','').replace('_','') }}OwnerEmailTag:
-    Value: !Ref "{{ email.split('@')[0].replace('.','').replace('-','').replace('_','') }}OwnerEmailTag"
-    Export:
-      Name: !Sub "${AWS::Region}-${AWS::StackName}-{{ email.split('@')[0].replace('.','').replace('-','').replace('_','') }}OwnerEmailTag"
-{% endfor %}
+{% if 'OwnerEmails' in sceptre_user_data %}
+  {% for email in sceptre_user_data.OwnerEmails %}
+    {{ email.split('@')[0].replace('.','').replace('-','').replace('_','') }}OwnerEmailTag:
+      Value: !Ref "{{ email.split('@')[0].replace('.','').replace('-','').replace('_','') }}OwnerEmailTag"
+      Export:
+        Name: !Sub "${AWS::Region}-${AWS::StackName}-{{ email.split('@')[0].replace('.','').replace('-','').replace('_','') }}OwnerEmailTag"
+  {% endfor %}
+{% endif %}


### PR DESCRIPTION
split templates to get around weird error that says the ref doesn't exist even though it is in same template
