### PR TITLE
Remove scaccounts stack

### DIFF
--- a/config/prod/sc-accounts.yaml
+++ b/config/prod/sc-accounts.yaml
@@ -1,8 +1,0 @@
-template_path: "sc-accounts.yaml"
-stack_name: "sc-accounts"
-dependencies:
-  - "prod/essentials.yaml"
-  - "prod/sc-enduser-iam.yaml"
-  - "prod/sc-enduser-development-iam.yaml"
-parameters:
-  InitNewUserPassword: !ssm "/infra/InitNewUserPassword"


### PR DESCRIPTION
Removes scaccounts
The user accounts in this have been decoupled from the stack
When we are ready to transition to using the synapse login only, we will need to remove those manually.
