### PR TITLE
Make reference to sc library name configurable

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -4,3 +4,4 @@ region: {{ var.region | default("us-east-1") }}
 template_bucket_name: "bootstrap-awss3cloudformationbucket-ut887whv3ote"
 template_key_prefix: {{ environment_variable.TRAVIS_BRANCH | default("testing") }}
 admincentral_cf_bucket: "bootstrap-awss3cloudformationbucket-19qromfd235z9"
+service_catalog_library: "scipoolprod-sc-lib-infra"

--- a/config/dev/sc-portfolio-ec2-development-tthyer.yaml
+++ b/config/dev/sc-portfolio-ec2-development-tthyer.yaml
@@ -5,12 +5,12 @@ stack_name: "sc-portfolio-ec2-development-tthyer"
 #   - "prod/sc-enduser-development-iam.yaml"
 parameters:
   LaunchRoleName: "SCEC2LaunchRole"
-  RepoRootURL: "https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/scipoolprod-sc-lib-infra/master/"
+  RepoRootURL: "https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/"
   PrincipalRoleName1: "ServiceCatalogDevelopmentEndusers"
   PrincipalGroupName1: "ServiceCatalogDevelopmentEndusers"
   StackDatetime: !date
 hooks:
   before_create:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/scipoolprod-sc-lib-infra/master/ec2/development/tthyer/sc-portfolio-ec2-development-tthyer.yaml --create-dirs -o templates/remote/sc-portfolio-ec2-development-tthyer.yaml"
+    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/ec2/development/tthyer/sc-portfolio-ec2-development-tthyer.yaml --create-dirs -o templates/remote/sc-portfolio-ec2-development-tthyer.yaml"
   before_update:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/scipoolprod-sc-lib-infra/master/ec2/development/tthyer/sc-portfolio-ec2-development-tthyer.yaml --create-dirs -o templates/remote/sc-portfolio-ec2-development-tthyer.yaml"
+    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/ec2/development/tthyer/sc-portfolio-ec2-development-tthyer.yaml --create-dirs -o templates/remote/sc-portfolio-ec2-development-tthyer.yaml"

--- a/config/dev/sc-portfolio-ec2-development.yaml
+++ b/config/dev/sc-portfolio-ec2-development.yaml
@@ -5,12 +5,12 @@ dependencies:
   - "prod/sc-enduser-development-iam.yaml"
 parameters:
   LaunchRoleName: "SCEC2LaunchRole"
-  RepoRootURL: "https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/scipoolprod-sc-lib-infra/master/"
+  RepoRootURL: "https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/"
   PrincipalRoleName1: "ServiceCatalogDevelopmentEndusers"
   PrincipalGroupName1: "ServiceCatalogDevelopmentEndusers"
   StackDatetime: !date
 hooks:
   before_create:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/scipoolprod-sc-lib-infra/master/ec2/development/sc-portfolio-ec2-development.yaml --create-dirs -o templates/remote/sc-portfolio-ec2-development.yaml"
+    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/ec2/development/sc-portfolio-ec2-development.yaml --create-dirs -o templates/remote/sc-portfolio-ec2-development.yaml"
   before_update:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/scipoolprod-sc-lib-infra/master/ec2/development/sc-portfolio-ec2-development.yaml --create-dirs -o templates/remote/sc-portfolio-ec2-development.yaml"
+    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/ec2/development/sc-portfolio-ec2-development.yaml --create-dirs -o templates/remote/sc-portfolio-ec2-development.yaml"

--- a/config/dev/sc-portfolio-s3-basic-development.yaml
+++ b/config/dev/sc-portfolio-s3-basic-development.yaml
@@ -7,10 +7,10 @@ parameters:
   LaunchRoleName: "SCS3LaunchRole"
   PrincipalRoleName1: "ServiceCatalogDevelopmentEndusers"
   PrincipalGroupName1: "ServiceCatalogDevelopmentEndusers"
-  RepoRootURL: "https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/scipoolprod-sc-lib-infra/master/"
+  RepoRootURL: "https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/"
   StackDatetime: !date
 hooks:
   before_create:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/scipoolprod-sc-lib-infra/master/s3/development/sc-portfolio-s3-basic-development.yaml --create-dirs -o templates/remote/sc-portfolio-s3-basic-development.yaml"
+    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/s3/development/sc-portfolio-s3-basic-development.yaml --create-dirs -o templates/remote/sc-portfolio-s3-basic-development.yaml"
   before_update:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/scipoolprod-sc-lib-infra/master/s3/development/sc-portfolio-s3-basic-development.yaml --create-dirs -o templates/remote/sc-portfolio-s3-basic-development.yaml"
+    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/s3/development/sc-portfolio-s3-basic-development.yaml --create-dirs -o templates/remote/sc-portfolio-s3-basic-development.yaml"

--- a/config/prod/AccountAlertTopics.yaml
+++ b/config/prod/AccountAlertTopics.yaml
@@ -10,7 +10,7 @@ parameters:
   SlackWebhookURL: !ssm "/infra/SlackWebhookUrl"
   SlackChannel: "#infra-notices"
 hooks:
-  before_create:
+  before_launch:
     - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/AccountAlertTopics.yaml --create-dirs -o templates/remote/AccountAlertTopics.yaml"
   before_update:
     - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/AccountAlertTopics.yaml --create-dirs -o templates/remote/AccountAlertTopics.yaml"

--- a/config/prod/sc-ec2-actions.yaml
+++ b/config/prod/sc-ec2-actions.yaml
@@ -11,4 +11,4 @@ parameters:
   AssumeRole: "arn:aws:iam::237179673806:role/SCEC2LaunchRole"
 hooks:
   before_launch:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/scipoolprod-sc-lib-infra/master/ec2/sc-ec2-actions.yaml --create-dirs -o templates/remote/sc-ec2-actions.yaml"
+    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/ec2/sc-ec2-actions.yaml --create-dirs -o templates/remote/sc-ec2-actions.yaml"

--- a/config/prod/sc-ec2vpc-launchrole.yaml
+++ b/config/prod/sc-ec2vpc-launchrole.yaml
@@ -4,6 +4,6 @@ dependencies:
   - "prod/essentials.yaml"
 hooks:
   before_create:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/scipoolprod-sc-lib-infra/master/iam/sc-ec2vpc-launchrole.yaml --create-dirs -o templates/remote/sc-ec2vpc-launchrole.yaml"
+    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/iam/sc-ec2vpc-launchrole.yaml --create-dirs -o templates/remote/sc-ec2vpc-launchrole.yaml"
   before_update:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/scipoolprod-sc-lib-infra/master/iam/sc-ec2vpc-launchrole.yaml --create-dirs -o templates/remote/sc-ec2vpc-launchrole.yaml"
+    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/iam/sc-ec2vpc-launchrole.yaml --create-dirs -o templates/remote/sc-ec2vpc-launchrole.yaml"

--- a/config/prod/sc-enduser-development-iam.yaml
+++ b/config/prod/sc-enduser-development-iam.yaml
@@ -6,6 +6,6 @@ parameters:
   RoleAndGroupName: ServiceCatalogDevelopmentEndusers
 hooks:
   before_create:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/scipoolprod-sc-lib-infra/master/iam/sc-enduser-iam.yaml --create-dirs -o templates/remote/sc-enduser-iam.yaml"
+    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/iam/sc-enduser-iam.yaml --create-dirs -o templates/remote/sc-enduser-iam.yaml"
   before_update:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/scipoolprod-sc-lib-infra/master/iam/sc-enduser-iam.yaml --create-dirs -o templates/remote/sc-enduser-iam.yaml"
+    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/iam/sc-enduser-iam.yaml --create-dirs -o templates/remote/sc-enduser-iam.yaml"

--- a/config/prod/sc-enduser-iam.yaml
+++ b/config/prod/sc-enduser-iam.yaml
@@ -4,6 +4,6 @@ dependencies:
   - "prod/essentials.yaml"
 hooks:
   before_create:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/scipoolprod-sc-lib-infra/master/iam/sc-enduser-iam.yaml --create-dirs -o templates/remote/sc-enduser-iam.yaml"
+    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/iam/sc-enduser-iam.yaml --create-dirs -o templates/remote/sc-enduser-iam.yaml"
   before_update:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/scipoolprod-sc-lib-infra/master/iam/sc-enduser-iam.yaml --create-dirs -o templates/remote/sc-enduser-iam.yaml"
+    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/iam/sc-enduser-iam.yaml --create-dirs -o templates/remote/sc-enduser-iam.yaml"

--- a/config/prod/sc-portfolio-ec2.yaml
+++ b/config/prod/sc-portfolio-ec2.yaml
@@ -7,10 +7,10 @@ parameters:
   LaunchRoleName: "SCEC2LaunchRole"
   PrincipalRoleName1: "ServiceCatalogEndusers"
   PrincipalGroupName1: "ServiceCatalogEndusers"
-  RepoRootURL: "https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/scipoolprod-sc-lib-infra/master/"
+  RepoRootURL: "https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/"
   StackDatetime: !date
 hooks:
   before_create:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/scipoolprod-sc-lib-infra/master/ec2/sc-portfolio-ec2.yaml --create-dirs -o templates/remote/sc-portfolio-ec2.yaml"
+    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/ec2/sc-portfolio-ec2.yaml --create-dirs -o templates/remote/sc-portfolio-ec2.yaml"
   before_update:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/scipoolprod-sc-lib-infra/master/ec2/sc-portfolio-ec2.yaml --create-dirs -o templates/remote/sc-portfolio-ec2.yaml"
+    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/ec2/sc-portfolio-ec2.yaml --create-dirs -o templates/remote/sc-portfolio-ec2.yaml"

--- a/config/prod/sc-portfolio-s3-basic.yaml
+++ b/config/prod/sc-portfolio-s3-basic.yaml
@@ -7,10 +7,10 @@ parameters:
   LaunchRoleName: "SCS3LaunchRole"
   PrincipalRoleName1: "ServiceCatalogEndusers"
   PrincipalGroupName1: "ServiceCatalogEndusers"
-  RepoRootURL: "https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/scipoolprod-sc-lib-infra/master/"
+  RepoRootURL: "https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/"
   StackDatetime: !date
 hooks:
   before_create:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/scipoolprod-sc-lib-infra/master/s3/sc-portfolio-s3-basic.yaml --create-dirs -o templates/remote/sc-portfolio-s3-basic.yaml"
+    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/s3/sc-portfolio-s3-basic.yaml --create-dirs -o templates/remote/sc-portfolio-s3-basic.yaml"
   before_update:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/scipoolprod-sc-lib-infra/master/s3/sc-portfolio-s3-basic.yaml --create-dirs -o templates/remote/sc-portfolio-s3-basic.yaml"
+    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/s3/sc-portfolio-s3-basic.yaml --create-dirs -o templates/remote/sc-portfolio-s3-basic.yaml"

--- a/config/prod/sc-s3-launchrole.yaml
+++ b/config/prod/sc-s3-launchrole.yaml
@@ -4,6 +4,6 @@ dependencies:
   - "prod/essentials.yaml"
 hooks:
   before_create:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/scipoolprod-sc-lib-infra/master/iam/sc-s3-launchrole.yaml --create-dirs -o templates/remote/sc-s3-launchrole.yaml"
+    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/iam/sc-s3-launchrole.yaml --create-dirs -o templates/remote/sc-s3-launchrole.yaml"
   before_update:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/scipoolprod-sc-lib-infra/master/iam/sc-s3-launchrole.yaml --create-dirs -o templates/remote/sc-s3-launchrole.yaml"
+    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/iam/sc-s3-launchrole.yaml --create-dirs -o templates/remote/sc-s3-launchrole.yaml"


### PR DESCRIPTION
Makes string used in urls for location of service catalog library configurable 
This will be followed up with a PR to replace the before_create and before_update hooks with the single before_launch hook.
